### PR TITLE
fix TypeError during runtime on 64bit Raspbian

### DIFF
--- a/picamera/bcm_host.py
+++ b/picamera/bcm_host.py
@@ -448,7 +448,7 @@ vc_dispmanx_update_start.argtypes = [ct.c_int32]
 vc_dispmanx_update_start.restype = DISPMANX_UPDATE_HANDLE_T
 
 vc_dispmanx_element_add = _lib.vc_dispmanx_element_add
-vc_dispmanx_element_add.argtypes = [DISPMANX_UPDATE_HANDLE_T, DISPMANX_DISPLAY_HANDLE_T, ct.c_int32, ct.POINTER(VC_RECT_T), DISPMANX_RESOURCE_HANDLE_T, ct.POINTER(VC_RECT_T), DISPMANX_PROTECTION_T, VC_DISPMANX_ALPHA_T, DISPMANX_CLAMP_T, DISPMANX_TRANSFORM_T]
+vc_dispmanx_element_add.argtypes = [DISPMANX_UPDATE_HANDLE_T, DISPMANX_DISPLAY_HANDLE_T, ct.c_int32, ct.POINTER(VC_RECT_T), DISPMANX_RESOURCE_HANDLE_T, ct.POINTER(VC_RECT_T), DISPMANX_PROTECTION_T, VC_DISPMANX_ALPHA_T, ct.POINTER(DISPMANX_CLAMP_T), ct.POINTER(DISPMANX_TRANSFORM_T)]
 vc_dispmanx_element_add.restype = DISPMANX_ELEMENT_HANDLE_T
 
 vc_dispmanx_element_change_source = _lib.vc_dispmanx_element_change_source


### PR DESCRIPTION
```
Traceback (most recent call last):
File "<string>", line 1, in <module>
File "/nix/store/cbqn8w15cnz8n5aan04z5y1dwlyr5jd3-python3-3.7.6-env/lib/python3.7/site-packages/picamera/__init__.py", line 72, in <module>  from picamera.exc import (                                                                                                                                                                                         File "/nix/store/cbqn8w15cnz8n5aan04z5y1dwlyr5jd3-python3-3.7.6-env/lib/python3.7/site-packages/picamera/exc.py", line 41, in <module>   import picamera.mmal as mmal
File "/nix/store/cbqn8w15cnz8n5aan04z5y1dwlyr5jd3-python3-3.7.6-env/lib/python3.7/site-packages/picamera/mmal.py", line 47, in <module>   from .bcm_host import VCOS_UNSIGNED
File "/nix/store/cbqn8w15cnz8n5aan04z5y1dwlyr5jd3-python3-3.7.6-env/lib/python3.7/site-packages/picamera/bcm_host.py", line 451, in <module>   vc_dispmanx_element_add.argtypes = [DISPMANX_UPDATE_HANDLE_T, DISPMANX_DISPLAY_HANDLE_T, ct.c_int32, ct.POINTER(VC_RECT_T), DISPMANX_RESOURCE_HANDLE_T, ct.POINTER(VC_RECT_T), DISPMANX_PROTECTION_T, VC_DISPMAN$_ALPHA_T, DISPMANX_CLAMP_T, DISPMANX_TRANSFORM_T]

TypeError: item 9 in _argtypes_ passes a union by value, which is unsupported.
```